### PR TITLE
Removing Screen width / manual width dependency

### DIFF
--- a/lib/SegmentedControl.style.ts
+++ b/lib/SegmentedControl.style.ts
@@ -1,29 +1,22 @@
-import { Dimensions, StyleSheet, ViewStyle } from "react-native";
-import { CustomStyleProp } from "./SegmentedControl";
-const { width: ScreenWidth } = Dimensions.get("screen");
+import { StyleSheet } from "react-native";
 
-export const _containerStyle = (width?: number): ViewStyle => ({
-  width: width || ScreenWidth - 32,
-  display: "flex",
-  flexDirection: "row",
-  alignItems: "center",
-  borderRadius: 8,
-  backgroundColor: "#F3F5F6",
-});
-
-export const _selectedTabStyle = (
-  tabs: any[],
-  activeTabColor: string,
-  translateXAnimation: any,
-  width?: number,
-): CustomStyleProp => [
-  {
-    ...StyleSheet.absoluteFillObject,
+export default StyleSheet.create({
+  container: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
     borderRadius: 8,
-    marginVertical: 2,
-    marginHorizontal: 2,
-    width: (width ? width - 8 : ScreenWidth - 35) / tabs?.length,
-    backgroundColor: activeTabColor,
+    backgroundColor: "#F3F5F6",
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 8, // iOS Default
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  activeTab: {
+    ...StyleSheet.absoluteFillObject,
+    borderRadius: 6,
     shadowColor: "#000",
     shadowOpacity: 0.2,
     shadowRadius: 3,
@@ -32,20 +25,6 @@ export const _selectedTabStyle = (
       height: 2,
     },
     elevation: 4,
-    transform: [
-      {
-        translateX: translateXAnimation,
-      },
-    ],
-  },
-];
-
-export default StyleSheet.create({
-  tab: {
-    flex: 1,
-    paddingVertical: 8, // iOS Default
-    alignItems: "center",
-    justifyContent: "center",
   },
   textStyle: {
     fontSize: 14, // iOS Default


### PR DESCRIPTION
Rather than calculating the width based off the screen size or passing in a fixed width, this change lets React Native handle sizing the component like any other `<View>` and then takes the calculated width from the onLayout event to calculate the correct active tab width.

The `width` and `extraSpacing` properties have been removed as they're no longer necessary.

That also let me remove all of the dynamic styling from the stylesheet and a couple of magic numbers from the active tab width calculations. The previously dynamic inline styles are now just passed directly into the `style` property.

The gap around the segments and the background is now also customisable by passing a `gap` property that defaults to the previous default size of 2 units.

I've tweaked the active tab's border radius to better follow the outer containers' radius too.

Also some missing `useEffect`/`useCallback` dependencies were added.

---

Apologies if I've run roughshod over any of your code linting/formatting rules, I've tried to keep it inline as much as possible with your existing code! Just let me know if you want me to tweak anything.

Also this is quite a big change to the way this component renders, so it's probably worth making it a breaking change considering the `width` and `extraSpacing` props are now gone.

Let me know if you'd like me to update the readme too.

Cheers!