### PR TITLE
feat: calc slideAnimation by tab layout

### DIFF
--- a/lib/SegmentedControl.style.ts
+++ b/lib/SegmentedControl.style.ts
@@ -9,6 +9,10 @@ export default StyleSheet.create<any>({
     borderRadius: 8,
     backgroundColor: "#F3F5F6",
   },
+  tabsContainer: {
+    flex: 1,
+    flexDirection: "row",
+  },
   tab: {
     flex: 1,
     paddingVertical: 8, // iOS Default

--- a/lib/SegmentedControl.tsx
+++ b/lib/SegmentedControl.tsx
@@ -20,7 +20,7 @@ interface SegmentedControlProps {
   activeTabColor?: string;
   gap?: number;
   style?: StyleProp<ViewStyle>;
-  tabStyle?: StyleProp<ViewStyle>;
+  tabStyle?: StyleProp<ViewStyle> | ((index: number) => StyleProp<ViewStyle>);
   textStyle?: StyleProp<TextStyle>;
   selectedTabStyle?: StyleProp<ViewStyle>;
   onChange: (index: number) => void;
@@ -41,8 +41,6 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
   activeTabColor = "#fff",
 }) => {
   const [slideAnimation, _] = useState(new Animated.Value(0));
-  const [width, setWidth] = useState<number>(0);
-  const tabWidth = Math.max(width / tabs.length - gap * 2, 0);
   const [localCurrentIndex, setCurrentIndex] = useState<number>(initialIndex);
   const [tabLayouts, setTabLayouts] = useState<{
     [tabIndex: number]: LayoutRectangle;
@@ -56,13 +54,6 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
       onChange && onChange(index);
     },
     [onChange],
-  );
-
-  const handleLayout = useCallback(
-    ({ nativeEvent }: LayoutChangeEvent) => {
-      setWidth(nativeEvent.layout.width);
-    },
-    [setWidth],
   );
 
   useEffect(() => {
@@ -83,16 +74,32 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
     [],
   );
 
+  const tabSpecificStyle = useCallback(
+    (tabIndex: number) => {
+      if (typeof tabStyle === "function") {
+        return tabStyle(tabIndex);
+      }
+
+      return tabStyle;
+    },
+    [tabStyle],
+  );
+
   const renderSelectedTab = useCallback(
     () => (
       <Animated.View
         style={[
-          styles.activeTab(tabWidth, gap, activeTabColor, slideAnimation),
+          styles.activeTab(
+            tabLayouts[currentIndex]?.width || 0,
+            gap,
+            activeTabColor,
+            slideAnimation,
+          ),
           selectedTabStyle,
         ]}
       />
     ),
-    [activeTabColor, gap, selectedTabStyle, slideAnimation, tabWidth],
+    [activeTabColor, gap, selectedTabStyle, slideAnimation, tabLayouts],
   );
 
   const renderTab = (tab: any, index: number) => {
@@ -102,7 +109,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
       <TouchableOpacity
         key={index}
         activeOpacity={0.5}
-        style={[styles.tab, tabStyle]}
+        style={[styles.tab, tabSpecificStyle(index)]}
         onPress={() => handleTabPress(index)}
         onLayout={(e) => onLayoutTab(index, e)}
       >
@@ -125,9 +132,11 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
   };
 
   return (
-    <View style={[styles.container, style]} onLayout={handleLayout}>
+    <View style={[styles.container, style]}>
       {renderSelectedTab()}
-      {tabs.map((tab, index: number) => renderTab(tab, index))}
+      <View style={[styles.tabsContainer, { marginHorizontal: gap }]}>
+        {tabs.map((tab, index: number) => renderTab(tab, index))}
+      </View>
     </View>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-segmented-control-2",
-  "version": "1.0.2",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-segmented-control-2",
-      "version": "1.0.2",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^15.0.0",


### PR DESCRIPTION
* Calculate the tab position for the slide animation via `onLayout`.
This allows a more flexible styling  (e.g. adding a left padding to the parent or tabs with different widths) without affecting the position of the active tab.

* Also allow the `tabStyle` prop to be a function. This allows to pass tab-specific styles (e.g. if you want tabs with different sizes)

example: 

```typescript
  tabStyle={(index: number) => {
      return index === 0 ? { flex: 2 } : { flex: 1 };
  }}
```