### PR TITLE
feat: add `activeTextStyle` prop

### DIFF
--- a/example/lib/SegmentedControl.tsx
+++ b/example/lib/SegmentedControl.tsx
@@ -21,6 +21,7 @@ interface SegmentedControlProps {
   style?: StyleProp<ViewStyle>;
   tabStyle?: StyleProp<ViewStyle>;
   textStyle?: StyleProp<TextStyle>;
+  activeTextStyle?: StyleProp<TextStyle>;
   selectedTabStyle?: StyleProp<ViewStyle>;
   onChange: (index: number) => void;
   value?: number;
@@ -33,6 +34,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
   value,
   tabStyle,
   textStyle,
+  activeTextStyle,
   selectedTabStyle,
   initialIndex = 0,
   gap = 2,
@@ -101,6 +103,7 @@ const SegmentedControl: React.FC<SegmentedControlProps> = ({
             style={[
               styles.textStyle,
               textStyle,
+              isActiveTab && activeTextStyle,
               isActiveTab && { color: activeTextColor },
             ]}
           >


### PR DESCRIPTION
This PR adds a new prop:
`activeTextStyle` to style the text of the active tab.